### PR TITLE
add aync opening camera while start

### DIFF
--- a/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/CameraPreview.java
+++ b/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/CameraPreview.java
@@ -3,9 +3,11 @@ package cn.bingoogolapple.qrcode.core;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.hardware.Camera;
+import android.os.Handler;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+
 
 public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback {
     private static final String TAG = CameraPreview.class.getSimpleName();
@@ -14,6 +16,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
     private boolean mAutoFocus = true;
     private boolean mSurfaceCreated = false;
     private CameraConfigurationManager mCameraConfigurationManager;
+	private Handler mshowCameraHandler = new Handler();
 
     public CameraPreview(Context context) {
         super(context);
@@ -45,7 +48,12 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
             return;
         }
         stopCameraPreview();
-        showCameraPreview();
+
+		mshowCameraHandler.post(new Runnable(){
+			public void run(){
+				showCameraPreview();
+			}
+		});
     }
 
     @Override


### PR DESCRIPTION
在启动的时候先弹出界面, 在打开相机, 这样用户会感到启动速度快点
Showing the interface at first, and then opening the camera which makes users feel faster when launching the app