### PR TITLE
高分屏下扫描框的实际扫描区域偏移的问题

### DIFF
--- a/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/ScanBoxView.java
+++ b/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/ScanBoxView.java
@@ -553,8 +553,8 @@ public class ScanBoxView extends View {
             Rect rect = new Rect(mFramingRect);
             float ratio = 1.0f * previewHeight / getMeasuredHeight();
 
-            float centerX = rect.exactCenterX();
-            float centerY = rect.exactCenterY();
+            float centerX = rect.exactCenterX()*ratio;
+            float centerY = rect.exactCenterY()*ratio;
 
             float halfWidth = rect.width() / 2f;
             float halfHeight = rect.height() / 2f;


### PR DESCRIPTION
这里的中心点应当以照片实际尺寸