### PR TITLE
Add SurfaceHolder.Callback on init in CameraPreview

### DIFF
--- a/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/CameraPreview.java
+++ b/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/CameraPreview.java
@@ -22,6 +22,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
 
     public CameraPreview(Context context) {
         super(context);
+        getHolder().addCallback(this);
     }
 
     void setCamera(Camera camera) {
@@ -30,7 +31,6 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
             mCameraConfigurationManager = new CameraConfigurationManager(getContext());
             mCameraConfigurationManager.initFromCameraParameters(mCamera);
 
-            getHolder().addCallback(this);
             if (mPreviewing) {
                 requestLayout();
             } else {


### PR DESCRIPTION
在 `CameraPreview` 构造的时候就调用 `getHolder().addCallback(this)`。

原因是 `setCamera` 方法不能保证能在 `CameraPreview` attach 到 Window 的时候被调用，如果使用方在以下场景里使用 `QRCodeView`，那么 `surfaceCreated` 将不会回调，这导致 `setOneShotPreviewCallback` 不会正确地设置从而无法识别： 

- `QRCodeView` 很早就被 `inflated` 而且被 attached 到 `Window`
- `startCamera` 系列打开摄像头的方法延迟执行