### PR TITLE
Update ProcessDataTask to fix a logic bug

### DIFF
--- a/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/ProcessDataTask.java
+++ b/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/ProcessDataTask.java
@@ -105,9 +105,7 @@ class ProcessDataTask extends AsyncTask<Void, Void, ScanResult> {
         if (mPicturePath != null) {
             return qrCodeView.processBitmapData(BGAQRCodeUtil.getDecodeAbleBitmap(mPicturePath));
         } else if (mBitmap != null) {
-            ScanResult result = qrCodeView.processBitmapData(mBitmap);
-            mBitmap = null;
-            return result;
+            return qrCodeView.processBitmapData(mBitmap);
         } else {
             if (BGAQRCodeUtil.isDebug()) {
                 BGAQRCodeUtil.d("两次任务执行的时间间隔：" + (System.currentTimeMillis() - sLastStartTime));


### PR DESCRIPTION
"mBitmap" should be set null only when onPostExecute function calling. then the function onPostParseBitmapOrPicture will be called rightly when pass param is bitmap not file path.