### PR TITLE
优化解码扫描区域的逻辑，使解码更快

### DIFF
--- a/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/QRCodeView.java
+++ b/qrcodecore/src/main/java/cn/bingoogolapple/qrcode/core/QRCodeView.java
@@ -315,7 +315,7 @@ public abstract class QRCodeView extends RelativeLayout implements Camera.Previe
             return;
         }
 
-        mProcessDataTask = new ProcessDataTask(camera, data, this, BGAQRCodeUtil.isPortrait(getContext())).perform();
+        mProcessDataTask = new ProcessDataTask(camera, data, this, mScanBoxView, BGAQRCodeUtil.isPortrait(getContext())).perform();
     }
 
     private void handleAmbientBrightness(byte[] data, Camera camera) {


### PR DESCRIPTION
当设置只解码扫描框区域时，在processData里，从原始图像数据中抽出扫描框区域图像数据，传递给QRCodeView的processData方法。这样做可以更快的解码出扫描框区域图像中的条码或者二维码。